### PR TITLE
chore(api): create v2.1 HTTP API version

### DIFF
--- a/src/main/java/io/cryostat/net/web/http/api/ApiVersion.java
+++ b/src/main/java/io/cryostat/net/web/http/api/ApiVersion.java
@@ -41,6 +41,7 @@ public enum ApiVersion {
     GENERIC(""),
     V1("v1"),
     V2("v2"),
+    V2_1("v2.1"),
     BETA("beta"),
     ;
 

--- a/src/main/java/io/cryostat/net/web/http/api/v2/AuthPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/AuthPostHandler.java
@@ -65,7 +65,7 @@ class AuthPostHandler extends AbstractV2RequestHandler<UserInfo> {
 
     @Override
     public ApiVersion apiVersion() {
-        return ApiVersion.V2;
+        return ApiVersion.V2_1;
     }
 
     @Override

--- a/src/test/java/itest/NoopAuthV2IT.java
+++ b/src/test/java/itest/NoopAuthV2IT.java
@@ -56,7 +56,7 @@ public class NoopAuthV2IT extends StandardSelfTest {
 
     @BeforeEach
     void createRequest() {
-        req = webClient.post("/api/v2/auth");
+        req = webClient.post("/api/v2.1/auth");
     }
 
     @Test


### PR DESCRIPTION
Fixes #710

This also re-assigns the new `POST /api/v2/auth` to `POST /api/v2.1/auth`, since this handler was just introduced and came after the v2 -> 2.1.0-SNAPSHOT tag point.