### PR TITLE
fix(httpapi): log more detail on HTTP API exceptions

### DIFF
--- a/src/main/java/io/cryostat/net/web/WebServer.java
+++ b/src/main/java/io/cryostat/net/web/WebServer.java
@@ -125,10 +125,22 @@ public class WebServer {
                         exception = new HttpStatusException(500, ctx.failure());
                     }
 
+                    String payload =
+                            exception.getPayload() != null
+                                    ? exception.getPayload()
+                                    : exception.getMessage();
                     if (!HttpStatusCodeIdentifier.isServerErrorCode(exception.getStatusCode())) {
-                        logger.warn(exception);
+                        logger.warn(
+                                "HTTP {}: {}\n{}",
+                                exception.getStatusCode(),
+                                payload,
+                                ExceptionUtils.getStackTrace(exception).trim());
                     } else {
-                        logger.error(exception);
+                        logger.error(
+                                "HTTP {}: {}\n{}",
+                                exception.getStatusCode(),
+                                payload,
+                                ExceptionUtils.getStackTrace(exception).trim());
                     }
 
                     if (exception.getStatusCode() == 401) {
@@ -153,11 +165,6 @@ public class WebServer {
                                 .end(gson.toJson(resp));
                     } else {
                         // kept for V1 API handler compatibility
-                        String payload =
-                                exception.getPayload() != null
-                                        ? exception.getPayload()
-                                        : exception.getMessage();
-
                         if (ExceptionUtils.hasCause(exception, HttpStatusException.class)) {
                             payload +=
                                     " caused by " + ExceptionUtils.getRootCauseMessage(exception);


### PR DESCRIPTION
Fixes #713

Here is a log snippet showing an intentional auth failure and a failed jfr-datasource upload (produced intentionally with a modified jfr-datasource that always responds with a 418 status):


```
Oct 12, 2021 6:53:58 PM io.cryostat.core.log.Logger warn
WARNING: HTTP 401: HTTP Authorization Failure
io.vertx.ext.web.handler.impl.HttpStatusException: Unauthorized
Oct 12, 2021 6:53:58 PM io.cryostat.core.log.Logger info
INFO: (10.0.2.100:53318): POST /api/v1/auth 401 8ms
Oct 12, 2021 6:53:59 PM io.cryostat.core.log.Logger info
INFO: (10.0.2.100:53318): POST /api/v1/auth 200 0ms
Oct 12, 2021 6:53:59 PM io.cryostat.core.log.Logger info
INFO: (10.0.2.100:53318): GET /api/v1/recordings 200 3ms
Oct 12, 2021 6:53:59 PM io.cryostat.core.log.Logger info
INFO: (10.0.2.100:53320): GET /api/v1/targets 200 4ms
Oct 12, 2021 6:54:00 PM io.cryostat.core.log.Logger info
INFO: Connected remote client 10.0.2.100:53328
Oct 12, 2021 6:54:00 PM io.cryostat.core.log.Logger info
INFO: Outgoing WS message: {"meta":{"category":"WsClientActivity","type":{"type":"application","subType":"json"},"serverTime":1634064840},"message":{"10.0.2.100:53328":"connected"}}
Oct 12, 2021 6:54:00 PM io.cryostat.core.log.Logger info
INFO: Creating connection for service:jmx:rmi:///jndi/rmi://cryostat:9093/jmxrmi
Oct 12, 2021 6:54:00 PM io.cryostat.core.log.Logger info
INFO: Authenticated remote client 10.0.2.100:53328
Oct 12, 2021 6:54:00 PM io.cryostat.core.log.Logger info
INFO: Outgoing WS message: {"meta":{"category":"WsClientActivity","type":{"type":"application","subType":"json"},"serverTime":1634064840},"message":{"10.0.2.100:53328":"accepted"}}
Oct 12, 2021 6:54:00 PM io.cryostat.core.log.Logger info
INFO: (10.0.2.100:53318): GET /api/v1/targets/service%3Ajmx%3Armi%3A%2F%2F%2Fjndi%2Frmi%3A%2F%2Fcryostat%3A9093%2Fjmxrmi/recordings 200 532ms
Oct 12, 2021 6:54:00 PM io.cryostat.core.log.Logger info
INFO: (10.0.2.100:53320): GET /api/v1/recordings 200 526ms
Oct 12, 2021 6:54:07 PM io.cryostat.core.log.Logger info
INFO: (10.0.2.100:53318): POST /api/v1/recordings 200 1414ms
Oct 12, 2021 6:54:07 PM io.cryostat.core.log.Logger info
INFO: Recording saved as jmx-listener-55d48f7cfc-p9st4_profiling_20211004T222522Z.jfr
Oct 12, 2021 6:54:07 PM io.cryostat.core.log.Logger info
INFO: Outgoing WS message: {"meta":{"category":"RecordingSaved","type":{"type":"application","subType":"json"},"serverTime":1634064847},"message":{"recording":"jmx-listener-55d48f7cfc-p9st4_profiling_20211004T222522Z.jfr"}}
Oct 12, 2021 6:54:07 PM io.cryostat.core.log.Logger info
INFO: (10.0.2.100:53318): GET /api/v1/recordings 200 10ms
Oct 12, 2021 6:54:09 PM io.cryostat.core.log.Logger error
SEVERE: HTTP 512: Invalid response from datasource server; datasource URL may be incorrect, or server may not be functioning properly: 418 Client Error (418)
io.vertx.ext.web.handler.impl.HttpStatusException: Server Error (512)
Oct 12, 2021 6:54:09 PM io.cryostat.core.log.Logger info
INFO: (10.0.2.100:53318): POST /api/v1/recordings/jmx-listener-55d48f7cfc-p9st4_profiling_20211004T222522Z.jfr/upload 512 94ms
Oct 12, 2021 6:54:10 PM io.cryostat.core.log.Logger info
INFO: Removing cached connection for service:jmx:rmi:///jndi/rmi://cryostat:9093/jmxrmi
```